### PR TITLE
fix: peer dependencies version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "homepage": "https://github.com/artemtam/react-perfect-slider#readme",
   "dependencies": {},
   "peerDependencies": {
-    "react": ">=^16.8",
-    "react-dom": ">=^16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
     "@semantic-release/git": "^9.0.0",


### PR DESCRIPTION
`>=^` is not a valid range descriptor and yarn would complain with `warning " > react-perfect-slider@2.0.0" has incorrect peer dependency "react@>=^16.8".`.